### PR TITLE
Add GetPathOriginal to Event interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - goconst
+    - gofmt
+    - golint
+    - gosimple
+    - ineffassign
+    - interfacer
+    - misspell
+    - staticcheck
+    - unconvert
+    - varcheck
+    - vet
+    - vetshadow
+    - errcheck
+    - govet
+    - structcheck
+    - typecheck
+
+run:
+
+  # timeout for analysis
+  timeout: 5m
+
+  skip-dirs:
+    - docs
+
+issues:
+
+  # List of regexps of issue texts to exclude
+  exclude:
+    - "comment on"
+    - "error should be the last"
+    - "should have comment"
+
+  exclude-rules:
+
+    # list of excluded linters applied on test files
+    - path: _test\.go
+      linters:
+        - goconst

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go_import_path: github.com/nuclio/nuclio-sdk-go
 go: 
-  - "1.10"
-  - "1.9"
+  - "1.14"
+  - "1.15"
 script: make test

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nuclio
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -39,6 +40,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestInterface(t *testing.T) {
+
 	// Check that WithStatusCode implements error interface
 	var err error = NewErrNotFound("missing page")
 
@@ -47,6 +49,9 @@ func TestInterface(t *testing.T) {
 	}
 }
 
-func TestErrorMethod(t *testing.T) {
-	ErrNotFound.Error()
+func ExampleErrNotFound() {
+	fmt.Print(ErrNotFound.Error())
+
+	// Output:
+	// Not Found
 }

--- a/event.go
+++ b/event.go
@@ -53,7 +53,7 @@ type Event interface {
 	// SetTriggerInfoProvider sets the information about the trigger who triggered this event
 	SetTriggerInfoProvider(TriggerInfoProvider)
 
-	// GetTriggerInfo retruns a trigger info provider
+	// GetTriggerInfo returns a trigger info provider
 	GetTriggerInfo() TriggerInfoProvider
 
 	// GetContentType returns the content type of the body
@@ -98,13 +98,16 @@ type Event interface {
 	// GetTimestamp returns when the event originated
 	GetTimestamp() time.Time
 
-	// GetPath returns the path of the event
+	// GetPath returns the urldecoded and normalized path of the event
 	GetPath() string
+
+	// GetPathOriginal returns the original path
+	GetPathOriginal() string
 
 	// GetURL returns the URL of the event
 	GetURL() string
 
-	// GetPath returns the method of the event, if applicable
+	// GetMethod returns the method of the event, if applicable
 	GetMethod() string
 
 	// GetShardID returns the ID of the shard from which this event arrived, if applicable
@@ -218,8 +221,13 @@ func (ae *AbstractEvent) GetTimestamp() time.Time {
 	return ae.emptyTime
 }
 
-// GetPath returns the path of the event
+// GetPath returns the urldecoded and normalized path of the event
 func (ae *AbstractEvent) GetPath() string {
+	return ""
+}
+
+// GetPathOriginal returns the original path
+func (ae *AbstractEvent) GetPathOriginal() string {
 	return ""
 }
 

--- a/memoryevent.go
+++ b/memoryevent.go
@@ -2,11 +2,12 @@ package nuclio
 
 type MemoryEvent struct {
 	AbstractEvent
-	Method      string
-	ContentType string
-	Body        []byte
-	Headers     map[string]interface{}
-	Path        string
+	Method       string
+	ContentType  string
+	Body         []byte
+	Headers      map[string]interface{}
+	Path         string
+	PathOriginal string
 }
 
 func (me *MemoryEvent) GetMethod() string {
@@ -32,6 +33,10 @@ func (me *MemoryEvent) GetBody() []byte {
 
 func (me *MemoryEvent) GetPath() string {
 	return me.Path
+}
+
+func (me *MemoryEvent) GetPathOriginal() string {
+	return me.PathOriginal
 }
 
 func (me *MemoryEvent) GetHeaders() map[string]interface{} {


### PR DESCRIPTION
Added `GetPathOriginal` to allow event message contain the original, not url decoded or normalized path

+ Fixed minor comment typos
