### PR TITLE
Add GetPathOriginal to Event interface

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.14', '1.13' ]
+        go: [ '1.15', '1.14' ]
     steps:
     - uses: actions/checkout@v2
 

--- a/event.go
+++ b/event.go
@@ -53,7 +53,7 @@ type Event interface {
 	// SetTriggerInfoProvider sets the information about the trigger who triggered this event
 	SetTriggerInfoProvider(TriggerInfoProvider)
 
-	// GetTriggerInfo retruns a trigger info provider
+	// GetTriggerInfo returns a trigger info provider
 	GetTriggerInfo() TriggerInfoProvider
 
 	// GetContentType returns the content type of the body
@@ -98,13 +98,16 @@ type Event interface {
 	// GetTimestamp returns when the event originated
 	GetTimestamp() time.Time
 
-	// GetPath returns the path of the event
+	// GetPath returns the urldecoded and normalized path of the event
 	GetPath() string
+
+	// GetPathOriginal returns the original path
+	GetPathOriginal() string
 
 	// GetURL returns the URL of the event
 	GetURL() string
 
-	// GetPath returns the method of the event, if applicable
+	// GetMethod returns the method of the event, if applicable
 	GetMethod() string
 
 	// GetShardID returns the ID of the shard from which this event arrived, if applicable
@@ -218,8 +221,13 @@ func (ae *AbstractEvent) GetTimestamp() time.Time {
 	return ae.emptyTime
 }
 
-// GetPath returns the path of the event
+// GetPath returns the urldecoded and normalized path of the event
 func (ae *AbstractEvent) GetPath() string {
+	return ""
+}
+
+// GetPathOriginal returns the original path
+func (ae *AbstractEvent) GetPathOriginal() string {
 	return ""
 }
 

--- a/event.go
+++ b/event.go
@@ -98,10 +98,10 @@ type Event interface {
 	// GetTimestamp returns when the event originated
 	GetTimestamp() time.Time
 
-	// GetPath returns the urldecoded and normalized path of the event
+	// GetPath returns the path of the event
 	GetPath() string
 
-	// GetPathOriginal returns the original path
+	// GetPathOriginal returns the original path of the event
 	GetPathOriginal() string
 
 	// GetURL returns the URL of the event
@@ -221,14 +221,14 @@ func (ae *AbstractEvent) GetTimestamp() time.Time {
 	return ae.emptyTime
 }
 
-// GetPath returns the urldecoded and normalized path of the event
+// GetPath returns the path of the event
 func (ae *AbstractEvent) GetPath() string {
 	return ""
 }
 
-// GetPathOriginal returns the original path
+// GetPathOriginal returns the original path of the event
 func (ae *AbstractEvent) GetPathOriginal() string {
-	return ""
+	return ae.GetPath()
 }
 
 // GetURL returns the URL of the event

--- a/memoryevent.go
+++ b/memoryevent.go
@@ -2,11 +2,12 @@ package nuclio
 
 type MemoryEvent struct {
 	AbstractEvent
-	Method      string
-	ContentType string
-	Body        []byte
-	Headers     map[string]interface{}
-	Path        string
+	Method       string
+	ContentType  string
+	Body         []byte
+	Headers      map[string]interface{}
+	Path         string
+	PathOriginal string
 }
 
 func (me *MemoryEvent) GetMethod() string {
@@ -32,6 +33,10 @@ func (me *MemoryEvent) GetBody() []byte {
 
 func (me *MemoryEvent) GetPath() string {
 	return me.Path
+}
+
+func (me *MemoryEvent) GetPathOriginal() string {
+	return me.PathOriginal
 }
 
 func (me *MemoryEvent) GetHeaders() map[string]interface{} {

--- a/memoryevent.go
+++ b/memoryevent.go
@@ -2,12 +2,11 @@ package nuclio
 
 type MemoryEvent struct {
 	AbstractEvent
-	Method       string
-	ContentType  string
-	Body         []byte
-	Headers      map[string]interface{}
-	Path         string
-	PathOriginal string
+	Method      string
+	ContentType string
+	Body        []byte
+	Headers     map[string]interface{}
+	Path        string
 }
 
 func (me *MemoryEvent) GetMethod() string {
@@ -33,10 +32,6 @@ func (me *MemoryEvent) GetBody() []byte {
 
 func (me *MemoryEvent) GetPath() string {
 	return me.Path
-}
-
-func (me *MemoryEvent) GetPathOriginal() string {
-	return me.PathOriginal
 }
 
 func (me *MemoryEvent) GetHeaders() map[string]interface{} {


### PR DESCRIPTION
Added `GetPathOriginal` to allow event message contain the original, not url decoded or normalized path

+ Fixed minor comment typos
