### PR TITLE
CI - Lock go version to 1.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.0"
+        go-version: "1.17.13"
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.17.0"
+        go-version: "1.17.0"
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
golangci not supported in latest go version 1.19 - https://github.com/golangci/golangci-lint-action/issues/532