### PR TITLE
[Event] Add GetTopic method to Event interface

### DIFF
--- a/event.go
+++ b/event.go
@@ -127,6 +127,9 @@ type Event interface {
 
 	// GetOffset returns the offset of the event
 	GetOffset() int
+
+	// GetTopic returns the topic of the event
+	GetTopic() string
 }
 
 // AbstractEvent provides a base implementation of an event
@@ -290,4 +293,9 @@ func (ae *AbstractEvent) GetLastInBatch() bool {
 // GetOffset returns the offset of the event
 func (ae *AbstractEvent) GetOffset() int {
 	return 0
+}
+
+// GetTopic returns the topic of the event
+func (ae *AbstractEvent) GetTopic() string {
+	return ""
 }


### PR DESCRIPTION
Add GetTopic method to Event interface to use `GetTopic` instead of `GetPath` for rpc events which is more intuitive for users.

Jira - https://jira.iguazeng.com/browse/NUC-18